### PR TITLE
feat: Use validation rules to determine if a field is required.

### DIFF
--- a/src/ts/selective/field.ts
+++ b/src/ts/selective/field.ts
@@ -190,6 +190,7 @@ export class Field
       'selective__field--guess': this.config.isGuessed || false,
       'selective__field--invalid': !this.isValid,
       'selective__field--linked': this.isDeepLinked,
+      'selective__field--required': this.validation?.isRequired() || false,
     };
 
     classes[`selective__field__type__${this.fieldType}`] = true;
@@ -636,10 +637,18 @@ export class Field
       this.config.label = guessLabel(this.config.key);
     }
 
+    let requiredMark = html``;
+
+    if (this.validation?.isRequired()) {
+      requiredMark = html`<span class="selective__field__label__required"
+        >*</span
+      >`;
+    }
+
     return html`<div class=${classMap(this.classesForLabel())}>
       ${this.templateIconDeepLink(editor, data)}
       ${this.templateIconValidation(editor, data)}
-      <label for=${this.uid}>${this.config.label}</label>
+      <label for=${this.uid}>${this.config.label}${requiredMark}</label>
     </div>`;
   }
 

--- a/src/ts/selective/rule/length.ts
+++ b/src/ts/selective/rule/length.ts
@@ -53,6 +53,13 @@ export class LengthRule extends Rule {
     return value;
   }
 
+  /**
+   * Field is considered required when there is a min value..
+   */
+  get isRequired(): boolean {
+    return Boolean(this.config.min && this.config.min.value > 0);
+  }
+
   validate(value: any): string | null {
     // Allow for empty fields.
     // Use the required rule for making sure it exists.

--- a/src/ts/selective/rule/range.ts
+++ b/src/ts/selective/rule/range.ts
@@ -53,6 +53,13 @@ export class RangeRule extends Rule {
     return value;
   }
 
+  /**
+   * Field is considered required when there is a min value..
+   */
+  get isRequired(): boolean {
+    return Boolean(this.config.min && this.config.min.value > 0);
+  }
+
   validate(value: any): string | null {
     // Allow for empty fields.
     // Use the required rule for making sure it exists.

--- a/src/ts/selective/rule/require.ts
+++ b/src/ts/selective/rule/require.ts
@@ -2,6 +2,10 @@ import {Rule, RuleConfig} from '../validationRules';
 import {DataType} from '../../utility/dataType';
 
 export interface RequireRuleConfig extends RuleConfig {
+  /**
+   * For some fields a blank is not an empty value. Allow for setting
+   * alternative values that are also considered as being empty.
+   */
   alternativeEmpties?: Array<string>;
 }
 
@@ -12,6 +16,13 @@ export class RequireRule extends Rule {
   constructor(config: RequireRuleConfig) {
     super(config);
     this.config = config;
+  }
+
+  /**
+   * Required rule makes the field required.
+   */
+  get isRequired(): boolean {
+    return true;
   }
 
   validate(value: any): string | null {

--- a/src/ts/selective/validation.ts
+++ b/src/ts/selective/validation.ts
@@ -78,6 +78,18 @@ export class Validation implements ValidationComponent {
     return resultsForZone.filter(filterFunc);
   }
 
+  /**
+   * Checks each of the rules to see if the field is required.
+   */
+  isRequired(zoneKey?: string): boolean {
+    for (const rule of this.rules.getRulesForZone(zoneKey)) {
+      if (rule.isRequired) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   getResults(
     zoneKey?: string,
     maxLevel?: ValidationLevel

--- a/src/ts/selective/validationRules.ts
+++ b/src/ts/selective/validationRules.ts
@@ -48,6 +48,18 @@ export interface RuleComponent {
   allowRemove(value: any): boolean;
 
   /**
+   * Does the rule make the value required?
+   *
+   * The UI needs to be able to mark fields that are required
+   * without needing to show the entire error state.
+   *
+   * If a validation rule makes it required, this allows the
+   * UI to flag the field for the user without a full error
+   * display.
+   */
+  isRequired: boolean;
+
+  /**
    * Validation level used if the validation fails.
    */
   level: ValidationLevel;
@@ -129,6 +141,15 @@ export class Rule extends Base implements RuleComponent {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   allowRemove(value: any): boolean {
     return true;
+  }
+
+  /**
+   * Does the rule make the value required?
+   *
+   * By default, a validation rule does not make the value required.
+   */
+  get isRequired(): boolean {
+    return false;
   }
 
   /**


### PR DESCRIPTION
This is a way to mark required fields without the validation needing to be triggered.