### PR TITLE
feat!: Focus tracking for field validation and gloval validation marking.

### DIFF
--- a/src/ts/mixins/option.ts
+++ b/src/ts/mixins/option.ts
@@ -52,6 +52,7 @@ export interface OptionUiComponent {
 }
 
 export interface OptionUIConfig {
+  handleBlur: (evt: Event) => void;
   handleInput: (evt: Event) => void;
   isMulti?: boolean;
   isOptionSelected: (option: Option) => boolean;
@@ -205,6 +206,7 @@ export function OptionMixin<TBase extends Constructor>(Base: TBase) {
         data-value=${option.value}
         tabindex="0"
         role=${config.isMulti ? 'checkbox' : 'radio'}
+        @blur=${config.handleBlur}
         @click=${config.handleInput}
         @keypress=${(evt: KeyboardEvent) => {
           if (evt.code === 'Space') {

--- a/src/ts/selective/editor.ts
+++ b/src/ts/selective/editor.ts
@@ -43,6 +43,14 @@ export class SelectiveEditor extends DataMixin(Base) {
   config: EditorConfig;
   container?: HTMLElement;
   fields: FieldsComponent;
+  /**
+   * Controls when the validation should be checked across all the
+   * fields in the editor.
+   *
+   * **Note:** Render cycle needs to complete before the validation can
+   * be trusted.
+   */
+  markValidation?: boolean;
   isPendingRender: boolean;
   isRendering: boolean;
   types: Types;

--- a/src/ts/selective/field/checkbox.ts
+++ b/src/ts/selective/field/checkbox.ts
@@ -51,7 +51,7 @@ export class CheckboxField extends OptionMixin(Field) {
     return value === this.config.value;
   }
 
-  handleInput(evt: Event) {
+  handleInput() {
     if (this.isChecked) {
       this.currentValue =
         this.config.valueUnchecked !== undefined
@@ -69,6 +69,7 @@ export class CheckboxField extends OptionMixin(Field) {
       editor,
       data,
       {
+        handleBlur: this.handleBlur.bind(this),
         handleInput: this.handleInput.bind(this),
         isMulti: true, // Treat it as multi-check option to show as checkbox.
         isOptionSelected: () => this.isChecked,
@@ -84,6 +85,7 @@ export class CheckboxField extends OptionMixin(Field) {
    * @param editor Selective editor used to render the template.
    * @param data Data provided to render the template.
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   templateLabel(editor: SelectiveEditor, data: DeepObject): TemplateResult {
     return html``;
   }

--- a/src/ts/selective/field/checkboxMulti.ts
+++ b/src/ts/selective/field/checkboxMulti.ts
@@ -65,6 +65,7 @@ export class CheckboxMultiField extends OptionMixin(Field) {
       editor,
       data,
       {
+        handleBlur: this.handleBlur.bind(this),
         handleInput: this.handleInput.bind(this),
         isMulti: true, // Treat it as multi-check option to show as checkboxes.
         isOptionSelected: (option: Option) => value.includes(option.value),

--- a/src/ts/selective/field/color.ts
+++ b/src/ts/selective/field/color.ts
@@ -27,6 +27,7 @@ export class ColorField extends Field {
         <input
           type="color"
           id="${this.uid}"
+          @blur=${this.handleBlur.bind(this)}
           @input=${this.handleInput.bind(this)}
           value=${value}
         />

--- a/src/ts/selective/field/date.ts
+++ b/src/ts/selective/field/date.ts
@@ -44,6 +44,7 @@ export class DateField extends Field {
         <input
           type="date"
           id="${this.uid}"
+          @blur=${this.handleBlur.bind(this)}
           @input=${this.handleInput.bind(this)}
           value=${value}
         />

--- a/src/ts/selective/field/datetime.ts
+++ b/src/ts/selective/field/datetime.ts
@@ -44,6 +44,7 @@ export class DatetimeField extends Field {
         <input
           type="datetime-local"
           id="${this.uid}"
+          @blur=${this.handleBlur.bind(this)}
           @input=${this.handleInput.bind(this)}
           value=${value}
         />

--- a/src/ts/selective/field/number.ts
+++ b/src/ts/selective/field/number.ts
@@ -56,6 +56,7 @@ export class NumberField extends Field {
           type="number"
           id="${this.uid}"
           placeholder=${this.config.placeholder || ''}
+          @blur=${this.handleBlur.bind(this)}
           @input=${this.handleInput.bind(this)}
           max=${this.config.max === undefined ? '' : this.config.max}
           min=${this.config.min === undefined ? '' : this.config.min}

--- a/src/ts/selective/field/radio.ts
+++ b/src/ts/selective/field/radio.ts
@@ -44,6 +44,7 @@ export class RadioField extends OptionMixin(Field) {
       editor,
       data,
       {
+        handleBlur: this.handleBlur.bind(this),
         handleInput: this.handleInput.bind(this),
         isMulti: false,
         isOptionSelected: (option: Option) =>

--- a/src/ts/selective/field/text.ts
+++ b/src/ts/selective/field/text.ts
@@ -34,6 +34,7 @@ export class TextField extends Field {
           type="text"
           id="${this.uid}"
           placeholder=${this.config.placeholder || ''}
+          @blur=${this.handleBlur.bind(this)}
           @input=${this.handleInput.bind(this)}
           value=${value}
         />

--- a/src/ts/selective/field/textarea.ts
+++ b/src/ts/selective/field/textarea.ts
@@ -43,6 +43,7 @@ export class TextareaField extends Field {
           id=${this.uid}
           rows=${this.config.rows || 6}
           placeholder=${this.config.placeholder || ''}
+          @blur=${this.handleBlur.bind(this)}
           @input=${this.handleInput.bind(this)}
           wrap=${this.config.wrap === undefined ? 'soft' : this.config.wrap}
         >

--- a/src/ts/selective/field/time.ts
+++ b/src/ts/selective/field/time.ts
@@ -44,6 +44,7 @@ export class TimeField extends Field {
         <input
           type="time"
           id="${this.uid}"
+          @blur=${this.handleBlur.bind(this)}
           @input=${this.handleInput.bind(this)}
           value=${value}
         />


### PR DESCRIPTION
Updating to allow the editor to be marked for global validation. Fields will also show validation if the field has lost focus indicating that the user is done with the input.

The main goal is to provide in context validation after user interaction in a non-intrusive way while also supporting whole form validation (ex: on 'submit').

Breaking change: `zoneToKey` is reworked to be `zones` with a structured value.

fixes #44 