### PR TITLE
feat: Delay validation on a form until it is marked for validation.

### DIFF
--- a/src/ts/selective/editor.ts
+++ b/src/ts/selective/editor.ts
@@ -37,6 +37,18 @@ export interface EditorConfig {
    * such as an api or additional global meta information.
    */
   global?: GlobalConfig;
+  /**
+   * Delay the validation until marked for validation.
+   *
+   * The default for the editor is to show validation messages after
+   * the user has left the fields. This provides a better user
+   * experience for longer forms but can be disruptive on smaller forms.
+   *
+   * By delaying the validation the editor will not run the field
+   * validation until the `markValidation` is set to `true` and
+   * the editor is re-rendered.
+   */
+  delayValidation?: boolean;
 }
 
 export class SelectiveEditor extends DataMixin(Base) {

--- a/src/ts/selective/field.ts
+++ b/src/ts/selective/field.ts
@@ -293,9 +293,11 @@ export class Field
     }
 
     // Only validate when the editor is marked for validation
-    // or the field has lost the user focus for a better
-    // untouched user experience.
-    if (this.hasLostFocus() || editor?.markValidation) {
+    // or the field has lost the user focus unless delayed.
+    if (
+      (!editor?.config.delayValidation && this.hasLostFocus()) ||
+      editor?.markValidation
+    ) {
       const zoneKeys = Object.keys(this.zones ?? {});
       const onlyDefaultZone =
         !this.zones ||


### PR DESCRIPTION
On long forms the user experience is enhanced by providing validation after the user has visited a field. But for shorter forms or other circumstances having immediate validation can be jarring for the experience. Using the delayed config allows the validation to be delayed for the entire editor until the editor has been marked for validation.