### PR TITLE
fix: Sortable items can bind the focus in/out to control draggable.

### DIFF
--- a/src/ts/mixins/sortable.ts
+++ b/src/ts/mixins/sortable.ts
@@ -8,6 +8,16 @@ export interface SortableFieldComponent {
 }
 
 export interface SortableUiComponent {
+  /**
+   * Is the sortable component currently draggable?
+   *
+   * If a user is focused inside a draggable object don't allow the
+   * item to be dragged.
+   *
+   * For instance, if there is an `input` inside of a draggable item
+   * you do not want to allow it to be dragged while in the input
+   * as that would mess up things like selecting text using the mouse.
+   */
   canDrag: boolean;
   listeners: Listeners;
   handleDragEnter(evt: DragEvent): void;
@@ -65,7 +75,6 @@ export class SortableUi extends UuidMixin(Base) implements SortableUiComponent {
 
     return null;
   }
-
   get canDrag(): boolean {
     return !this.dragFocused;
   }

--- a/src/ts/mixins/sortable.ts
+++ b/src/ts/mixins/sortable.ts
@@ -203,9 +203,6 @@ export class SortableUi extends UuidMixin(Base) implements SortableUiComponent {
     // Reset the drag element.
     this.dragOrigin = undefined;
 
-    // Reset the can drag check.
-    this.dragFocused = false;
-
     this.listeners.trigger('sort', startIndex, currentIndex, target);
   }
 

--- a/src/ts/selective/field/list.ts
+++ b/src/ts/selective/field/list.ts
@@ -2,7 +2,7 @@ import {DeepObject, autoDeepObject} from '../../utility/deepObject';
 import {Field, FieldComponent, FieldConfig} from '../field';
 import {GlobalConfig, SelectiveEditor} from '../editor';
 import {SortableFieldComponent, SortableMixin} from '../../mixins/sortable';
-import {TemplateResult, html} from 'lit-html';
+import {TemplateResult, html, render} from 'lit-html';
 
 import {Base} from '../../mixins';
 import {DataType} from '../../utility/dataType';
@@ -588,13 +588,21 @@ export class ListFieldItem
         'selective__list__item--no-drag': this.listField.length <= 1,
         selective__sortable: true,
       })}
-      draggable=${canDrag ? 'true' : 'false'}
+      draggable=${canDrag && sortable.canDrag ? 'true' : 'false'}
       data-index=${index}
       @dragenter=${sortable.handleDragEnter.bind(sortable)}
       @dragleave=${sortable.handleDragLeave.bind(sortable)}
       @dragover=${sortable.handleDragOver.bind(sortable)}
       @dragstart=${sortable.handleDragStart.bind(sortable)}
       @drop=${sortable.handleDrop.bind(sortable)}
+      @focusin=${(evt: FocusEvent) => {
+        sortable.handleFocusIn(evt);
+        this.listField.render();
+      }}
+      @focusout=${(evt: FocusEvent) => {
+        sortable.handleFocusOut(evt);
+        this.listField.render();
+      }}
     >
       <div class="selective__field__actions selective__field__actions--pre">
         ${preActions}
@@ -617,14 +625,26 @@ export class ListFieldItem
     data: DeepObject,
     index: number
   ): TemplateResult {
+    const canDrag = this.listField.length > 1;
     const sortable = this.listField.sortableUi;
+
     return html` <div
       class="selective__list__item selective__list__item--expanded selective__sortable"
+      draggable=${canDrag && sortable.canDrag ? 'true' : 'false'}
       data-index=${index}
       @dragenter=${sortable.handleDragEnter.bind(sortable)}
       @dragleave=${sortable.handleDragLeave.bind(sortable)}
       @dragover=${sortable.handleDragOver.bind(sortable)}
+      @dragstart=${sortable.handleDragStart.bind(sortable)}
       @drop=${sortable.handleDrop.bind(sortable)}
+      @focusin=${(evt: FocusEvent) => {
+        sortable.handleFocusIn(evt);
+        this.listField.render();
+      }}
+      @focusout=${(evt: FocusEvent) => {
+        sortable.handleFocusOut(evt);
+        this.listField.render();
+      }}
     >
       <div
         class="selective__list__fields__header"
@@ -697,13 +717,21 @@ export class ListFieldItem
 
     return html` <div
       class="selective__list__item selective__list__item--simple selective__sortable"
-      draggable=${canDrag ? 'true' : 'false'}
+      draggable=${canDrag && sortable.canDrag ? 'true' : 'false'}
       data-index=${index}
       @dragenter=${sortable.handleDragEnter.bind(sortable)}
       @dragleave=${sortable.handleDragLeave.bind(sortable)}
       @dragover=${sortable.handleDragOver.bind(sortable)}
       @dragstart=${sortable.handleDragStart.bind(sortable)}
       @drop=${sortable.handleDrop.bind(sortable)}
+      @focusin=${(evt: FocusEvent) => {
+        sortable.handleFocusIn(evt);
+        this.listField.render();
+      }}
+      @focusout=${(evt: FocusEvent) => {
+        sortable.handleFocusOut(evt);
+        this.listField.render();
+      }}
     >
       <div class="selective__field__actions selective__field__actions--pre">
         ${preActions}


### PR DESCRIPTION
Currently when dragging it doesn't have any logic to no allow the item to be draggable, so when you try to select text in a field it drags the item instead.

fixes #58