### PR TITLE
fix: List sorting without changing positions does not change dirty.

### DIFF
--- a/src/ts/mixins/sortable.ts
+++ b/src/ts/mixins/sortable.ts
@@ -75,6 +75,7 @@ export class SortableUi extends UuidMixin(Base) implements SortableUiComponent {
 
     return null;
   }
+
   get canDrag(): boolean {
     return !this.dragFocused;
   }


### PR DESCRIPTION
Also do checking to see if sorted back to the original values to unlock the list.

fixes #64