### PR TITLE
fix: Duplicate configuration for list items.

### DIFF
--- a/src/ts/selective/field.ts
+++ b/src/ts/selective/field.ts
@@ -299,12 +299,9 @@ export class Field
       editor?.markValidation
     ) {
       const zoneKeys = Object.keys(this.zones ?? {});
-      const onlyDefaultZone =
-        !this.zones ||
-        (zoneKeys.length === 1 && zoneKeys[0] === DEFAULT_ZONE_KEY);
 
-      if (!this.zones || onlyDefaultZone) {
-        // Simple field with only the default zone.
+      if (!this.zones) {
+        // Simple field.
         this.validation.validate(this.currentValue);
       } else {
         // Complex field, validate each zone separately.

--- a/src/ts/selective/field/list.ts
+++ b/src/ts/selective/field/list.ts
@@ -14,6 +14,7 @@ import {UuidMixin} from '../../mixins/uuid';
 import {classMap} from 'lit-html/directives/class-map.js';
 import {repeat} from 'lit-html/directives/repeat.js';
 import stringify from 'json-stable-stringify';
+import cloneDeep from 'lodash.clonedeep';
 
 export interface ListFieldConfig extends FieldConfig {
   /**
@@ -160,7 +161,9 @@ export class ListField
     return new this.types.globals.FieldsCls(
       this.types,
       {
-        fields: fieldConfigs,
+        // Field configs should not be 'shared'. Duplicate the field configs
+        // before creating the fields.
+        fields: cloneDeep(fieldConfigs),
         isGuessed: this.usingAutoFields,
         parentKey: this.fullKey,
         previewField: this.config.previewField,

--- a/src/ts/selective/rule/match.ts
+++ b/src/ts/selective/rule/match.ts
@@ -50,7 +50,7 @@ export class MatchRule extends Rule {
               inValues = true;
               break;
             }
-          } else if (possibleValue === value) {
+          } else if (possibleValue == value) {
             inValues = true;
             break;
           }
@@ -79,7 +79,7 @@ export class MatchRule extends Rule {
             if ((possibleValue as RegExp).test(value)) {
               return matchConfig.message || this.message;
             }
-          } else if (possibleValue === value) {
+          } else if (possibleValue == value) {
             return matchConfig.message || this.message;
           }
         }


### PR DESCRIPTION
When lists are creating sub fields the configuration variable was being shared between different list items. Since it is mutable, when the validation was being generated for special fields the validation rules were being shared with all list items.